### PR TITLE
Allow partial animation importing (makes animation swaps easier)

### DIFF
--- a/io_import_pmm_animation.py
+++ b/io_import_pmm_animation.py
@@ -76,6 +76,8 @@ class PokeMastAnimImport(bpy.types.Operator, ImportHelper):
 		scn.frame_end = self.maxFrames
 		bpy.context.scene.render.fps = fps
 		for boneName in Animation.keys():
+			if boneName not in armature.pose.bones:
+				continue
 			bonePos = armature.pose.bones[boneName]
 			bone = armature.data.bones[boneName]
 			bonePos.rotation_mode = "QUATERNION"


### PR DESCRIPTION
Request to allow the plugin to continue to import the rest of the animation, even if one or more of the bones aren't present on the receiving model